### PR TITLE
AWS GraphFrame

### DIFF
--- a/Lab_6.ipynb
+++ b/Lab_6.ipynb
@@ -336,8 +336,12 @@
    "source": [
     "%%writefile $python_file\n",
     "\n",
+    "import sys\n",
+    "from pyspark import SparkContext\n",
     "from graphframes import *\n",
     "from pyspark.sql import SQLContext\n",
+    "\n",
+    "sc = SparkContext(appName=\"GraphFrameApp\")\n",
     "\n",
     "sqlContext = SQLContext(sc)\n",
     "\n",
@@ -357,7 +361,7 @@
     "\n",
     "resultsRdd = results.vertices.select(\"id\", \"pagerank\").rdd.map(lambda x: (x[0], x[1]))\n",
     "\n",
-    "resultsRdd.coalesce(1).saveAsTextFile(\"hdfs:/tmp/SparkGraphFrame\")"
+    "resultsRdd.coalesce(1).saveAsTextFile(sys.argv[1]) # передается как аргумент команды для запуска"
    ]
   },
   {
@@ -406,6 +410,89 @@
     "    \t<div style=\"display:table-cell; width:20%; text-align:center; background-color:whitesmoke; border:1px solid lightgrey\"><a href=\"#0\">К содержанию</a></div>\n",
     "    </div>\n",
     "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Заливаем код в S3. E.g.: s3://vasnetsov-lab-1/lab5/code.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "aws s3 cp lab6/myGraph.py s3://vasnetsov-lab-1/lab5/code.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Запуск python кода в спарке возможет только при загрузке с локальной машины, поэтому, при запуске кластера необходимо выполнить bootstrap actions, который скопирует код на машины из S3:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# bt_action.sh\n",
+    "aws s3 cp \"$1\" \"$2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Скрипт bootstrap actions также записываем в S3:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "aws s3 cp lab6/bt_action.sh s3://vasnetsov-lab-1/lab5/bt_action.sh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Комманда для запуска кластера, запуск Spark задачи, сохранение результата в S3 и завершение кластера:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "aws emr create-cluster --name \"GraphFrame_cluster\" \\\n",
+    "--release-label emr-5.2.0 \\\n",
+    "--applications Name=Spark \\\n",
+    "--log-uri s3://vasnetsov-lab-1/lab5/logs/ \\\n",
+    "--use-default-roles \\\n",
+    "--ec2-attributes KeyName=hadoop_keys,SubnetId=subnet-55b50d3d \\\n",
+    "--instance-type m4.large \\\n",
+    "--instance-count 3 \\\n",
+    "--auto-terminate \\\n",
+    "--bootstrap-actions 'Path=s3://vasnetsov-lab-1/lab5/bt_action.sh,Args=[s3://vasnetsov-lab-1/lab5/code.py,/home/hadoop/code.py]' \\\n",
+    "--steps 'Type=Spark,Name=GraphFrameApp,Args=[--packages,graphframes:graphframes:0.3.0-spark2.0-s_2.11,--conf,spark.yarn.submit.waitAppCompletion=false,/home/hadoop/code.py,s3://vasnetsov-lab-1/lab5/SparkGraphFrame/],ActionOnFailure=CONTINUE'"
    ]
   },
   {
@@ -624,7 +711,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Добавил запуск python-spark задач в AWS с захватом кода из S3 и сохранением результата туда же. Кластер терминируется сразу после завершения задачи 